### PR TITLE
Issues/1

### DIFF
--- a/ywangvaster_webapp/candidate_app/forms.py
+++ b/ywangvaster_webapp/candidate_app/forms.py
@@ -134,7 +134,7 @@ class RateCandidateForm(forms.Form):
     confidence = forms.ChoiceField(
         choices=confidence_choices,
         label="Confidence",
-        widget=forms.Select(attrs={"class": "form-select"}),
+        widget=forms.Select(attrs={"class": "form-select", "autofocus": True}),
     )
     tag = forms.ModelChoiceField(
         queryset=models.Tag.objects.all(),

--- a/ywangvaster_webapp/candidate_app/views.py
+++ b/ywangvaster_webapp/candidate_app/views.py
@@ -355,10 +355,12 @@ def candidate_rating(request, cand_hash_id, arcmin=2):
                 date=timezone.now(),
             )
 
-            # TODO - change this to go to a random page for a candidate that's not been rated yet in same set of candidates
-            # This is done with the NEXT button??
-
-            return redirect(request.META["HTTP_REFERER"])
+            if prev_rating:
+                # Updating an existing rating: stay on the same page
+                return redirect(request.META["HTTP_REFERER"])
+            else:
+                # New rating: go straight to the next unrated candidate
+                return redirect("candidate_random")
 
     # Convert the lightcurve data to mJy and put into a form for Echarts to use.
     converted_lc = []

--- a/ywangvaster_webapp/templates/candidate_app/candidate_rating.html
+++ b/ywangvaster_webapp/templates/candidate_app/candidate_rating.html
@@ -133,7 +133,7 @@
 
                 {% else %}
                 <button class='btn btn-primary' id='submit-rating' type='submit'>
-                  Rate
+                  Rate &amp; next &rsaquo;
                 </button>
                 {% endif %}
               </div>


### PR DESCRIPTION
Removes the page reload between rating and going to the next candidate.

Also adds autofocus to the rating pane, allowing the user to immediately being using the keyboard to input a rating. This may not be what is required - we may want to also add a specific keyboard shortcut to focus this no matter where the user currently is. 

As discussed, there is no "Back" button or way to 'rate and stay on this page' - if the user really wants to go back, they can use the browser back button. However, note that if updating a rating the user is not moved to a new candidate.

Closes #1 